### PR TITLE
fix: fix seeding of shipping options to make sure they work in storefront

### DIFF
--- a/apps/backend/src/migration-scripts/initial-data-seed.ts
+++ b/apps/backend/src/migration-scripts/initial-data-seed.ts
@@ -234,7 +234,7 @@ export default async function initial_data_seed({
         rules: [
           {
             attribute: "enabled_in_store",
-            value: '"true"',
+            value: "true",
             operator: "eq",
           },
           {
@@ -272,7 +272,7 @@ export default async function initial_data_seed({
         rules: [
           {
             attribute: "enabled_in_store",
-            value: '"true"',
+            value: "true",
             operator: "eq",
           },
           {


### PR DESCRIPTION
Fix the seeding of shipping options, which currently add them as admin only