### PR TITLE
fix: clarify product option selection state

### DIFF
--- a/apps/storefront/src/modules/products/components/product-actions/index.tsx
+++ b/apps/storefront/src/modules/products/components/product-actions/index.tsx
@@ -176,9 +176,9 @@ export default function ProductActions({
           isLoading={isAdding}
           data-testid="add-product-button"
         >
-          {!selectedVariant && !options
-            ? "Select variant"
-            : !inStock || !isValidVariant
+          {!selectedVariant || !isValidVariant
+            ? "Select size"
+            : !inStock
             ? "Out of stock"
             : "Add to cart"}
         </Button>

--- a/apps/storefront/src/modules/products/components/product-actions/mobile-actions.tsx
+++ b/apps/storefront/src/modules/products/components/product-actions/mobile-actions.tsx
@@ -124,7 +124,7 @@ const MobileActions: React.FC<MobileActionsProps> = ({
                 data-testid="mobile-cart-button"
               >
                 {!variant
-                  ? "Select variant"
+                  ? "Select size"
                   : !inStock
                   ? "Out of stock"
                   : "Add to cart"}


### PR DESCRIPTION
## What changed

Clarify the add-to-cart button state when a product option or size has not been selected.

## Why

The current desktop action label can show `Out of stock` before a variant is selected. That makes a missing selection look like an inventory problem and is confusing for customers.

## Implementation

- Check for a missing or invalid variant before checking inventory.
- Use `Select size` until a valid size/variant is selected.
- Keep `Out of stock` for a selected variant with no available inventory.
- Apply consistent wording to desktop and mobile actions.

## Validation

- The patch is limited to the desktop and mobile product-action components.
- No inventory, backend, or dependency changes are included.

Closes #44