### PR TITLE
fix(storefront): size the Text shim to the storefront's own base size

### DIFF
--- a/apps/storefront/src/modules/common/components/ui/index.tsx
+++ b/apps/storefront/src/modules/common/components/ui/index.tsx
@@ -23,7 +23,7 @@ type TextProps = HTMLAttributes<HTMLParagraphElement> & {
 export const Text = forwardRef<HTMLParagraphElement, TextProps>(
   ({ className, as: Component = "p", children, ...props }, ref) => {
     return (
-      <Component ref={ref} className={clsx("text-base", className)} {...props}>
+      <Component ref={ref} className={clsx("txt-medium", className)} {...props}>
         {children}
       </Component>
     )


### PR DESCRIPTION
## What this changes

`modules/common/components/ui` re-implements a few `@medusajs/ui` components
locally. Its `Text` hard-codes Tailwind's `text-base`, 1rem.

**In this storefront's own type scale, 1rem is not the base size.**
`globals.css` defines:

```css
.text-small-regular  { @apply text-xs  ... }   /* 12px */
.text-base-regular   { @apply text-sm  ... }   /* 14px */
.text-large-regular  { @apply text-base ... }  /* 16px */
```

Base is 14px here; 16px is "large". Usage agrees — 47 uses of
`text-small-regular` and 39 of `text-base-regular` against 2 of
`text-large-regular`, which is reserved for prominence. The shim makes that
accent size the default for every `<Text>` in the storefront.

The design system says the same thing for the same value, which is the
corroboration rather than the argument: `@medusajs/ui`'s `Text` resolves its
defaults — `size: "base"`, `leading: "normal"` — to `txt-medium`, which
`@medusajs/ui-preset` defines as `0.875rem`. The storefront's own scale and the
design system agree on 14px; only the shim disagrees.

## Where it shows

Most screens absorb it, because a `Text` rarely sits flush against an element
sized by the project's own typography classes. The order line item is the
exception — `modules/order/components/item` renders them as siblings:

```tsx
<Text className="text-ui-fg-muted">
  <span data-testid="product-quantity">{item.quantity}</span>x{" "}
</Text>
<LineItemUnitPrice item={item} style="tight" currencyCode={currencyCode} />
```

`LineItemUnitPrice` sizes the price with `text-base-regular`, which
`globals.css` defines as `@apply text-sm leading-6 font-normal` — 14px. The
quantity beside it is 16px, and the difference is visible on the order
confirmation and account order screens.

Most of the trap is in the naming: `text-base-regular` is not "`text-base` at
regular weight", it is a project utility resolving to `text-sm`. Two class
names implying the same size, differing by 2px.

## Why `txt-medium` and not `text-sm`

`text-sm` would give the right font size with Tailwind's `1.25rem` line height.
`txt-medium` carries the preset's `1.4rem`, so it matches the design system
exactly rather than approximately. The storefront already loads
`@medusajs/ui-preset` and uses `txt-medium` in a dozen components, so nothing
new is introduced.

## Verification

Measured in a browser against unpatched `main` as a control, on the same page:

| | before | after |
| --- | --- | --- |
| every element rendered by the shim's `Text` | 16px | 14px |

`tsc --noEmit` is clean.

## Noticed while doing this — not fixed here

The shim exports `clx` as plain `clsx`:

```ts
// Re-export clsx as clx for compatibility
export { clsx as clx }
```

`@medusajs/ui`'s `clx` is `twMerge(clsx(...))`. Without `tailwind-merge`, a
hard-coded default wins over a conflicting class passed by the caller instead
of losing to it, so call sites cannot override sizes. Measured on `main`:

```
text-base txt-compact-small   -> 16px   (txt-compact-small is 12px)
text-base text-base-regular   -> 16px   (text-base-regular is 14px)
```

That affects all 18 `clsx(...)` merge sites in the file, not just `Text`.
Fixing it properly means adding `tailwind-merge`, which this package
deliberately does not depend on — so it seemed like your call rather than
something to slip into this PR. Happy to open a follow-up if you want it.
