### PR TITLE
fix(storefront): stop right-aligning account values under their labels

### DIFF
--- a/apps/storefront/src/modules/account/components/account-info/index.tsx
+++ b/apps/storefront/src/modules/account/components/account-info/index.tsx
@@ -46,7 +46,7 @@ const AccountInfo = ({
       <div className="flex items-end justify-between">
         <div className="flex flex-col">
           <span className="uppercase text-ui-fg-base">{label}</span>
-          <div className="flex items-center flex-1 basis-0 justify-end gap-x-4">
+          <div className="flex items-center flex-1 basis-0 gap-x-4">
             {typeof currentInfo === "string" ? (
               <span className="font-semibold" data-testid="current-info">{currentInfo}</span>
             ) : (


### PR DESCRIPTION
## What this changes

`AccountInfo` stacks a label above its value in a flex column, and the value's
container carries `justify-end`:

```tsx
<div className="flex flex-col">
  <span className="uppercase text-ui-fg-base">{label}</span>
  <div className="flex items-center flex-1 basis-0 justify-end gap-x-4">
```

The column is as wide as its widest child. Whenever the **label** is the wider
of the two, `justify-end` pushes the value to the right edge of that column —
so the value renders indented, under a left-aligned label.

## Why it is invisible in English

No English value is narrower than its label: `EMAIL` sits above an email
address, `PHONE` above a phone number. The column is always sized by the value,
so `justify-end` has nothing to push against.

Translate the labels and it appears. On a Russian build, `ЭЛЕКТРОННАЯ ПОЧТА`
above a short address is the first row to show it, and it looks like a stray
indent on one row of an otherwise flush list.

## Measurement

Rendered with the storefront's own stylesheet, same markup, two variants:

| variant | label | label width | value width | value indent |
| --- | --- | --- | --- | --- |
| `justify-end` (current) | `Электронная почта` | 133px | 55px | **78px** |
| without it (this PR) | `Электронная почта` | 133px | 55px | **0px** |
| `justify-end` (current) | `Имя` | 78px | 78px | 0px |
| without it (this PR) | `Имя` | 78px | 78px | 0px |

The indent is exactly `labelWidth − valueWidth` when the label is wider, and
zero otherwise.

**English rendering does not change.** Where the value is already the wider of
the two — every row in the English build — both variants measure 0px, because
`justify-end` was a no-op there all along.

`tsc --noEmit` is clean.

## Note

`justify-end` looks copied from the other half of the same row, where the
**Edit** button genuinely is right-aligned and the class belongs. Here the
value should follow its label.
