### PR TITLE
fix(storefront): correct the order payment status test id

### DIFF
--- a/apps/storefront/src/modules/order/components/order-details/index.tsx
+++ b/apps/storefront/src/modules/order/components/order-details/index.tsx
@@ -48,7 +48,7 @@ const OrderDetails = ({ order, showStatus }: OrderDetailsProps) => {
               Payment status:{" "}
               <span
                 className="text-ui-fg-subtle "
-                sata-testid="order-payment-status"
+                data-testid="order-payment-status"
               >
                 {formatStatus(order.payment_status)}
               </span>


### PR DESCRIPTION
## What this changes

One character. The payment status span in `order-details` carries
`sata-testid` instead of `data-testid`:

```tsx
<span
  className="text-ui-fg-subtle "
  sata-testid="order-payment-status"
>
```

So the element has no test id. React passes the unknown attribute through to
the DOM, where it means nothing, and any selector looking for
`order-payment-status` finds no element.

Its siblings in the same component are all spelled correctly —
`order-email`, `order-date`, `order-id`, `order-status` — which makes this a
typo rather than a deliberate omission, and the payment status the only field
on the screen that cannot be asserted on.

Noticed while reading the component for something unrelated.
