### PR TITLE
fix(storefront): stop labelling an unselected product "Out of stock"

### DIFF
--- a/apps/storefront/src/modules/products/components/product-actions/index.tsx
+++ b/apps/storefront/src/modules/products/components/product-actions/index.tsx
@@ -176,7 +176,7 @@ export default function ProductActions({
           isLoading={isAdding}
           data-testid="add-product-button"
         >
-          {!selectedVariant && !options
+          {!selectedVariant
             ? "Select variant"
             : !inStock || !isValidVariant
             ? "Out of stock"


### PR DESCRIPTION
## What this changes

The add-to-cart button chooses its label like this:

```tsx
{!selectedVariant && !options
  ? "Select variant"
  : !inStock || !isValidVariant
  ? "Out of stock"
  : "Add to cart"}
```

`options` is component state, initialised to an object:

```tsx
const [options, setOptions] = useState<Record<string, string | undefined>>({})
```

An object is always truthy, so `!options` is never true and the first branch is
unreachable. A shopper who has not picked a variant yet falls through to the
second branch — `inStock` is false without a `selectedVariant` — and the button
reads **"Out of stock"**.

This is not a rare state. It is what every multi-variant product page shows on
arrival, before any interaction: the product is announced as unavailable while
its option buttons sit there waiting to be clicked.

## The mobile bar already does it correctly

`mobile-actions.tsx`, in the same folder, has the shape the desktop button was
meant to have:

```tsx
{!variant
  ? "Select variant"
  : !inStock
  ? "Out of stock"
  : "Add to cart"}
```

That asymmetry is what suggests the `&& !options` is a leftover rather than a
decision, so this PR just drops it.

## Verification

Server-rendered HTML for the seeded t-shirt, page untouched, counting the
labels of `add-product-button` and `mobile-cart-button`:

| | desktop buttons | mobile buttons |
| --- | --- | --- |
| before | `Out of stock` | `Select variant` |
| after | `Select variant` | `Select variant` |

Reproduced on a deployed store as well as locally, so it is not a dev-mode
artefact.

## Scope

One condition. The button's `disabled` prop is untouched — it already includes
`!selectedVariant`, so an unselected product stays unclickable exactly as
before. Only the label changes, and only in the state that was previously
mislabelled: a product genuinely out of stock still reads "Out of stock",
because by then a variant is selected.
