### PR TITLE
fix(storefront): stop the order details page crashing without a shipping method

### DIFF
--- a/apps/storefront/src/modules/order/components/shipping-details/index.tsx
+++ b/apps/storefront/src/modules/order/components/shipping-details/index.tsx
@@ -58,7 +58,7 @@ const ShippingDetails = ({ order }: ShippingDetailsProps) => {
           <Text className="txt-medium text-ui-fg-subtle">
             {(order.shipping_methods?.[0] as { name?: string })?.name} (
             {convertToLocale({
-              amount: order.shipping_methods?.[0].total ?? 0,
+              amount: order.shipping_methods?.[0]?.total ?? 0,
               currency_code: order.currency_code,
             })}
             )


### PR DESCRIPTION
## What this changes

The order details page reads the shipping method's price like this:

```tsx
{(order.shipping_methods?.[0] as { name?: string })?.name} (
{convertToLocale({
  amount: order.shipping_methods?.[0].total ?? 0,
  currency_code: order.currency_code,
})}
)
```

The array is guarded; the element is not.

Optional chaining short-circuits the entire chain, so `shipping_methods` being
`undefined` is safe — `?.[0].total` simply yields `undefined`. An **empty
array** is a different case: `[][0]` is `undefined`, and reading `.total` on it
throws before `?? 0` can apply:

```
TypeError: Cannot read properties of undefined (reading 'total')
```

The component is a client component, so the throw happens during render and the
whole page fails. The customer gets a blank screen, or `Application error: a
client-side exception has occurred` where there is no error boundary.

The line immediately above already carries the guard — `?.name` — which is what
makes this look like a missing character rather than a missing idea.

## Who hits it

Any order with no shipping method. Two ordinary ways to get one:

- an order created through `createOrderWorkflow` without `shipping_methods`
- a draft order completed without a delivery method

The store API returns `shipping_methods: []` for those, so it is the empty-array
case rather than the undefined one, and every visit to that order's page fails.

## Verification

Signed in as a customer with two orders on a real store — one with a shipping
method, one without — using the production build rather than dev, since the dev
overlay hides how the failure actually presents.

| order | before | after |
| --- | --- | --- |
| without a shipping method | page does not render | renders, showing a zero price and no method name |
| with a shipping method | renders | renders, showing the method name and its price |

Reverting the one character and rebuilding reproduces the failure, so the check
is capable of failing.

## Scope

One character. The rendered output for an order that *has* a method is
unchanged, and an order without one now shows a zero price rather than nothing
at all. Whether that empty state deserves better presentation — hiding the block
rather than showing a blank name — seemed a separate question from stopping the
crash, so it is not in this PR.
