### PR TITLE
feat(storefront): take the store name from the environment

### DIFF
--- a/apps/storefront/.env.template
+++ b/apps/storefront/.env.template
@@ -11,6 +11,11 @@ NEXT_PUBLIC_DEFAULT_REGION=dk
 # Base URL of the storefront (used for generating absolute URLs)
 NEXT_PUBLIC_BASE_URL=https://localhost:8000
 
+# Public name of the store, shown in the nav, footer, side menu, checkout
+# header, page titles and account pages. Optional: an unset value falls back to
+# "Medusa Store". Compiled in at build time, so changing it needs a rebuild.
+NEXT_PUBLIC_STORE_NAME=
+
 # Stripe publishable key for payment processing (optional, only if using Stripe)
 NEXT_PUBLIC_STRIPE_KEY=
 

--- a/apps/storefront/src/app/[countryCode]/(checkout)/layout.tsx
+++ b/apps/storefront/src/app/[countryCode]/(checkout)/layout.tsx
@@ -1,4 +1,5 @@
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
+import { getStoreName } from "@lib/util/env"
 import ChevronDown from "@modules/common/icons/chevron-down"
 import MedusaCTA from "@modules/layout/components/medusa-cta"
 
@@ -29,7 +30,7 @@ export default function CheckoutLayout({
             className="txt-compact-xlarge-plus text-ui-fg-subtle hover:text-ui-fg-base uppercase"
             data-testid="store-link"
           >
-            Medusa Store
+            {getStoreName()}
           </LocalizedClientLink>
           <div className="flex-1 basis-0" />
         </nav>

--- a/apps/storefront/src/app/[countryCode]/(main)/account/@dashboard/profile/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/account/@dashboard/profile/page.tsx
@@ -7,10 +7,11 @@ import ProfileName from "@modules/account/components/profile-name"
 import { notFound } from "next/navigation"
 import { listRegions } from "@lib/data/regions"
 import { retrieveCustomer } from "@lib/data/customer"
+import { getStoreName } from "@lib/util/env"
 
 export const metadata: Metadata = {
   title: "Profile",
-  description: "View and edit your Medusa Store profile.",
+  description: `View and edit your ${getStoreName()} profile.`,
 }
 
 export default async function Profile() {

--- a/apps/storefront/src/app/[countryCode]/(main)/account/@login/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/account/@login/page.tsx
@@ -1,10 +1,11 @@
 import { Metadata } from "next"
 
 import LoginTemplate from "@modules/account/templates/login-template"
+import { getStoreName } from "@lib/util/env"
 
 export const metadata: Metadata = {
   title: "Sign in",
-  description: "Sign in to your Medusa Store account.",
+  description: `Sign in to your ${getStoreName()} account.`,
 }
 
 export default function Login() {

--- a/apps/storefront/src/app/[countryCode]/(main)/categories/[...category]/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/categories/[...category]/page.tsx
@@ -51,12 +51,13 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   try {
     const productCategory = await getCategoryByHandle(params.category)
 
-    const title = productCategory.name + " | Medusa Store"
+    const title = `${productCategory.name} | Medusa Store`
 
-    const description = productCategory.description ?? `${title} category.`
+    const description =
+      productCategory.description ?? `${productCategory.name} category.`
 
     return {
-      title: `${title} | Medusa Store`,
+      title,
       description,
       alternates: {
         canonical: `${params.category.join("/")}`,

--- a/apps/storefront/src/app/[countryCode]/(main)/categories/[...category]/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/categories/[...category]/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next"
 import { notFound } from "next/navigation"
 
 import { getCategoryByHandle, listCategories } from "@lib/data/categories"
+import { getStoreName } from "@lib/util/env"
 import { listRegions } from "@lib/data/regions"
 import { HttpTypes, StoreRegion } from "@medusajs/types"
 import CategoryTemplate from "@modules/categories/templates"
@@ -51,7 +52,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   try {
     const productCategory = await getCategoryByHandle(params.category)
 
-    const title = `${productCategory.name} | Medusa Store`
+    const title = `${productCategory.name} | ${getStoreName()}`
 
     const description =
       productCategory.description ?? `${productCategory.name} category.`

--- a/apps/storefront/src/app/[countryCode]/(main)/collections/[handle]/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/collections/[handle]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation"
 
 import { getCollectionByHandle, listCollections } from "@lib/data/collections"
 import { listRegions } from "@lib/data/regions"
+import { getStoreName } from "@lib/util/env"
 import { StoreCollection, StoreRegion } from "@medusajs/types"
 import CollectionTemplate from "@modules/collections/templates"
 import { SortOptions } from "@modules/store/components/refinement-list/sort-products"
@@ -63,7 +64,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   }
 
   const metadata = {
-    title: `${collection.title} | Medusa Store`,
+    title: `${collection.title} | ${getStoreName()}`,
     description: `${collection.title} collection`,
   } as Metadata
 

--- a/apps/storefront/src/app/[countryCode]/(main)/products/[handle]/page.tsx
+++ b/apps/storefront/src/app/[countryCode]/(main)/products/[handle]/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next"
 import { notFound } from "next/navigation"
 import { listProducts } from "@lib/data/products"
 import { getRegion, listRegions } from "@lib/data/regions"
+import { getStoreName } from "@lib/util/env"
 import ProductTemplate from "@modules/products/templates"
 import { HttpTypes } from "@medusajs/types"
 
@@ -87,11 +88,13 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     notFound()
   }
 
+  const storeName = getStoreName()
+
   return {
-    title: `${product.title} | Medusa Store`,
+    title: `${product.title} | ${storeName}`,
     description: `${product.title}`,
     openGraph: {
-      title: `${product.title} | Medusa Store`,
+      title: `${product.title} | ${storeName}`,
       description: `${product.title}`,
       images: product.thumbnail ? [product.thumbnail] : [],
     },

--- a/apps/storefront/src/lib/util/env.ts
+++ b/apps/storefront/src/lib/util/env.ts
@@ -1,3 +1,13 @@
 export const getBaseURL = () => {
   return process.env.NEXT_PUBLIC_BASE_URL || "https://localhost:8000"
 }
+
+// The store's public name. Shown in the nav, the footer, the side menu, the
+// checkout header, page titles and the account pages.
+//
+// Optional: an unset value falls back to the starter's own name, so a fresh
+// clone is a working storefront rather than one with a blank wordmark. Next.js
+// inlines NEXT_PUBLIC_* at build time, so changing it needs a rebuild.
+export const getStoreName = () => {
+  return process.env.NEXT_PUBLIC_STORE_NAME || "Medusa Store"
+}

--- a/apps/storefront/src/modules/account/components/register/index.tsx
+++ b/apps/storefront/src/modules/account/components/register/index.tsx
@@ -7,6 +7,7 @@ import ErrorMessage from "@modules/checkout/components/error-message"
 import { SubmitButton } from "@modules/checkout/components/submit-button"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
 import { signup } from "@lib/data/customer"
+import { getStoreName } from "@lib/util/env"
 
 type Props = {
   setCurrentView: (view: LOGIN_VIEW) => void
@@ -21,11 +22,11 @@ const Register = ({ setCurrentView }: Props) => {
       data-testid="register-page"
     >
       <h1 className="text-large-semi uppercase mb-6">
-        Become a Medusa Store Member
+        Become a {getStoreName()} Member
       </h1>
       <p className="text-center text-base-regular text-ui-fg-base mb-4">
-        Create your Medusa Store Member profile, and get access to an enhanced
-        shopping experience.
+        Create your {getStoreName()} Member profile, and get access to an
+        enhanced shopping experience.
       </p>
       {message?.state === "verification_required" && (
         <div
@@ -81,7 +82,7 @@ const Register = ({ setCurrentView }: Props) => {
           data-testid="register-error"
         />
         <span className="text-center text-ui-fg-base text-small-regular mt-6">
-          By creating an account, you agree to Medusa Store&apos;s{" "}
+          By creating an account, you agree to {getStoreName()}&apos;s{" "}
           <LocalizedClientLink
             href="/content/privacy-policy"
             className="underline"

--- a/apps/storefront/src/modules/layout/components/side-menu/index.tsx
+++ b/apps/storefront/src/modules/layout/components/side-menu/index.tsx
@@ -5,6 +5,7 @@ import useToggleState from "@lib/hooks/use-toggle-state"
 import { ArrowRightMini, XMark } from "@medusajs/icons"
 import { HttpTypes } from "@medusajs/types"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
+import { getStoreName } from "@lib/util/env"
 import { Text, clx } from "@modules/common/components/ui"
 import { Fragment } from "react"
 import CountrySelect from "../country-select"
@@ -127,8 +128,8 @@ const SideMenu = ({ regions, locales, currentLocale }: SideMenuProps) => {
                         />
                       </div>
                       <Text className="flex justify-between txt-compact-small">
-                        © {new Date().getFullYear()} Medusa Store. All rights
-                        reserved.
+                        © {new Date().getFullYear()} {getStoreName()}. All
+                        rights reserved.
                       </Text>
                     </div>
                   </div>

--- a/apps/storefront/src/modules/layout/templates/footer/index.tsx
+++ b/apps/storefront/src/modules/layout/templates/footer/index.tsx
@@ -1,5 +1,6 @@
 import { listCategories } from "@lib/data/categories";
 import { listCollections } from "@lib/data/collections";
+import { getStoreName } from "@lib/util/env";
 import { Text, clx } from "@modules/common/components/ui";
 
 import LocalizedClientLink from "@modules/common/components/localized-client-link";
@@ -20,7 +21,7 @@ export default async function Footer() {
               href="/"
               className="txt-compact-xlarge-plus text-ui-fg-subtle hover:text-ui-fg-base uppercase"
             >
-              Medusa Store
+              {getStoreName()}
             </LocalizedClientLink>
           </div>
           <div className="text-small-regular gap-10 md:gap-x-16 grid grid-cols-2 sm:grid-cols-3">
@@ -147,7 +148,7 @@ export default async function Footer() {
         </div>
         <div className="flex w-full mb-16 justify-between text-ui-fg-muted">
           <Text className="txt-compact-small">
-            © {new Date().getFullYear()} Medusa Store. All rights reserved.
+            © {new Date().getFullYear()} {getStoreName()}. All rights reserved.
           </Text>
           <MedusaCTA />
         </div>

--- a/apps/storefront/src/modules/layout/templates/nav/index.tsx
+++ b/apps/storefront/src/modules/layout/templates/nav/index.tsx
@@ -3,6 +3,7 @@ import { Suspense } from "react"
 import { listLocales } from "@lib/data/locales"
 import { getLocale } from "@lib/data/locale-actions"
 import { listRegions } from "@lib/data/regions"
+import { getStoreName } from "@lib/util/env"
 import { StoreRegion } from "@medusajs/types"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
 import CartButton from "@modules/layout/components/cart-button"
@@ -31,7 +32,7 @@ export default async function Nav() {
               className="txt-compact-xlarge-plus hover:text-ui-fg-base uppercase"
               data-testid="nav-store-link"
             >
-              Medusa Store
+              {getStoreName()}
             </LocalizedClientLink>
           </div>
 


### PR DESCRIPTION
## What this changes

`"Medusa Store"` is written out in fifteen places across ten files:

| where | count |
| --- | --- |
| nav wordmark, footer wordmark, checkout header | 3 |
| footer and side menu copyright lines | 2 |
| category, collection and product title suffixes | 5 |
| profile and sign-in page descriptions | 2 |
| registration heading, body copy and terms line | 3 |

Renaming the store therefore means finding all fifteen, and missing one leaves
the shop introducing itself under two different names — most visibly in the
browser title, which is the one place a customer sees the name without looking
for it.

They now read `NEXT_PUBLIC_STORE_NAME` through a `getStoreName()` accessor
placed beside the existing `getBaseURL()`:

```ts
export const getStoreName = () => {
  return process.env.NEXT_PUBLIC_STORE_NAME || "Medusa Store"
}
```

**An unset value renders exactly as before.** This changes nothing for anyone
who does not set the variable, and a fresh clone still shows a real name rather
than a blank wordmark.

## The first commit is a bug fix

The category page could not be converted as-is, because it builds its title
twice:

```tsx
const title = productCategory.name + " | Medusa Store"

const description = productCategory.description ?? `${title} category.`

return {
  title: `${title} | Medusa Store`,
  ...
}
```

`title` already carries the suffix, and then the suffix is appended again, so
every category page renders as:

```
Shirts | Medusa Store | Medusa Store
```

The same variable is the base of the description fallback, so a category with no
description of its own gets `Shirts | Medusa Store category.` rather than
`Shirts category.`

Both follow from one cause: `title` conflates the page title with the category
name. Building the title from `productCategory.name` and returning it unchanged
fixes both, and matches how the collection page already derives its own
description.

This is committed separately, first, because it stands on its own — but it
cannot simply be left for later, since substituting the variable into those two
lines unchanged would have produced `Shirts | My Store | My Store`. Happy to
split it into its own PR if you would rather review it apart from the rest.

## Why `NEXT_PUBLIC_`

The nav, side menu and registration form are client components, so the value has
to reach the browser. A shop's own name on its own storefront is not a secret.

Being `NEXT_PUBLIC_`, it is inlined at build time, so changing it needs a
rebuild rather than a restart. That is noted in `.env.template` beside the
variable, which is listed as optional alongside the existing
`NEXT_PUBLIC_BASE_URL` and `NEXT_PUBLIC_STRIPE_KEY`.

## Verification

`pnpm exec tsc --noEmit` in `apps/storefront` is clean, and

```
git grep -n "Medusa Store" -- apps/storefront/src
```

returns exactly one line — the fallback inside `getStoreName()`. Every other
occurrence now goes through the accessor.

Titles, derived from the code above:

| page | before | after, unset | after, `NEXT_PUBLIC_STORE_NAME=Acme` |
| --- | --- | --- | --- |
| category | `Shirts \| Medusa Store \| Medusa Store` | `Shirts \| Medusa Store` | `Shirts \| Acme` |
| collection | `Summer \| Medusa Store` | `Summer \| Medusa Store` | `Summer \| Acme` |
| product | `T-Shirt \| Medusa Store` | `T-Shirt \| Medusa Store` | `T-Shirt \| Acme` |

The category row is the bug fix; the other two are unchanged when the variable
is unset.

## Scope

Only the storefront's own name. The `MedusaCTA` "Powered by" credit in the
footer and checkout is deliberately untouched — that is an attribution to Medusa
and Next.js, not the shop's name, and renaming a store should not remove it.

The two files this touches that are not prettier-clean at `main` — `footer` uses
semicolons against the repo's own `semi: false` — are left as they are rather
than reformatted, to keep the diff to the change itself.
